### PR TITLE
Add Swagger API documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "express": "^4.19.2",
     "express-validator": "^7.0.1",
     "jsonwebtoken": "^9.0.2",
-    "mongoose": "^8.5.2"
+    "mongoose": "^8.5.2",
+    "swagger-ui-express": "^4.6.3"
   },
   "devDependencies": {
     "nodemon": "^3.1.4",
@@ -26,6 +27,7 @@
     "@types/express": "^4.17.21",
     "@types/cors": "^2.8.17",
     "@types/jsonwebtoken": "^9.0.2",
-    "@types/bcrypt": "^5.0.2"
+    "@types/bcrypt": "^5.0.2",
+    "@types/swagger-ui-express": "^4.1.4"
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -25,10 +25,14 @@ import challengesRoutes from './routes/challenges';
 import rewardsRoutes from './routes/rewards';
 import leaderboardsRoutes from './routes/leaderboards';
 import tiersRoutes from './routes/tiers';
+import swaggerUi from 'swagger-ui-express';
+import swaggerDocument from './swagger';
 
 const app = express();
 app.use(cors());
 app.use(express.json());
+
+app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 app.use('/api/auth', authRoutes);
 app.use('/api/me', meRoutes);

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -1,0 +1,249 @@
+const swaggerDocument: any = {
+  openapi: '3.0.0',
+  info: {
+    title: 'Gamification API',
+    version: '1.0.0'
+  },
+  servers: [{ url: '/api' }],
+  components: {
+    securitySchemes: {
+      bearerAuth: {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT'
+      }
+    }
+  },
+  security: [{ bearerAuth: [] }],
+  paths: {
+    '/auth/signup': {
+      post: {
+        summary: 'User signup',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  email: { type: 'string' },
+                  password: { type: 'string' },
+                  name: { type: 'string' },
+                  partnerOrgName: { type: 'string' },
+                  partnerType: { type: 'string' },
+                  role: { type: 'string' }
+                },
+                required: ['email', 'password']
+              }
+            }
+          }
+        },
+        responses: {
+          '200': { description: 'JWT token and user info' }
+        }
+      }
+    },
+    '/auth/login': {
+      post: {
+        summary: 'User login',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  email: { type: 'string' },
+                  password: { type: 'string' }
+                },
+                required: ['email', 'password']
+              }
+            }
+          }
+        },
+        responses: {
+          '200': { description: 'JWT token and user info' }
+        }
+      }
+    },
+    '/me': {
+      get: {
+        summary: 'Get current user',
+        responses: {
+          '200': { description: 'User object' }
+        }
+      }
+    },
+    '/events/events': {
+      post: {
+        summary: 'Process activity event',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  idempotencyKey: { type: 'string' },
+                  userId: { type: 'string' },
+                  type: { type: 'string' }
+                },
+                required: ['idempotencyKey', 'userId', 'type']
+              }
+            }
+          }
+        },
+        responses: {
+          '200': { description: 'Processed activity event' }
+        }
+      }
+    },
+    '/deals/register': {
+      post: {
+        summary: 'Register a deal',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string' },
+                  amount: { type: 'number' }
+                },
+                required: ['name', 'amount']
+              }
+            }
+          }
+        },
+        responses: {
+          '200': { description: 'Deal created' }
+        }
+      }
+    },
+    '/deals/{id}/approve': {
+      post: {
+        summary: 'Approve a deal',
+        parameters: [
+          { name: 'id', in: 'path', required: true, schema: { type: 'string' } }
+        ],
+        responses: {
+          '200': { description: 'Deal updated' }
+        }
+      }
+    },
+    '/deals/{id}/close': {
+      post: {
+        summary: 'Close a deal',
+        parameters: [
+          { name: 'id', in: 'path', required: true, schema: { type: 'string' } }
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  outcome: { type: 'string' }
+                },
+                required: ['outcome']
+              }
+            }
+          }
+        },
+        responses: {
+          '200': { description: 'Deal closed' }
+        }
+      }
+    },
+    '/training/complete': {
+      post: {
+        summary: 'Mark training complete',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  trackCode: { type: 'string' },
+                  score: { type: 'number' }
+                },
+                required: ['trackCode']
+              }
+            }
+          }
+        },
+        responses: {
+          '200': { description: 'Training marked complete' }
+        }
+      }
+    },
+    '/challenges': {
+      post: {
+        summary: 'Create a challenge',
+        responses: {
+          '200': { description: 'Challenge created' }
+        }
+      },
+      get: {
+        summary: 'List active challenges',
+        responses: {
+          '200': { description: 'List of challenges' }
+        }
+      }
+    },
+    '/challenges/{id}/progress': {
+      get: {
+        summary: 'Get challenge progress',
+        parameters: [
+          { name: 'id', in: 'path', required: true, schema: { type: 'string' } }
+        ],
+        responses: {
+          '200': { description: 'Challenge progress' }
+        }
+      }
+    },
+    '/rewards/catalog': {
+      get: {
+        summary: 'List reward catalog',
+        responses: {
+          '200': { description: 'List of rewards' }
+        }
+      }
+    },
+    '/rewards/redeem/{rewardId}': {
+      post: {
+        summary: 'Redeem a reward',
+        parameters: [
+          { name: 'rewardId', in: 'path', required: true, schema: { type: 'string' } }
+        ],
+        responses: {
+          '200': { description: 'Redemption result' }
+        }
+      }
+    },
+    '/leaderboards/{key}': {
+      get: {
+        summary: 'Get leaderboard snapshot',
+        parameters: [
+          { name: 'key', in: 'path', required: true, schema: { type: 'string' } }
+        ],
+        responses: {
+          '200': { description: 'Leaderboard data' }
+        }
+      }
+    },
+    '/tiers/me': {
+      get: {
+        summary: 'Get tier status for current user',
+        responses: {
+          '200': { description: 'Tier status' }
+        }
+      }
+    }
+  }
+};
+
+export default swaggerDocument;


### PR DESCRIPTION
## Summary
- add Swagger UI and docs route
- document existing endpoints with OpenAPI spec

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fbcrypt)*
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b111f284832c819227188fb11991